### PR TITLE
Error in windows due to character encoding during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ import os, json, imp
 
 here = os.path.abspath(os.path.dirname(__file__))
 proj_info = json.loads(open(os.path.join(here, PROJ_METADATA)).read())
-README = open(os.path.join(here, 'README.rst')).read()
-CHANGELOG = open(os.path.join(here, 'CHANGELOG.rst')).read()
+README = open(os.path.join(here, 'README.rst'), encoding="utf-8").read()
+CHANGELOG = open(os.path.join(here, 'CHANGELOG.rst'), encoding="utf-8").read()
 VERSION = imp.load_source('version', os.path.join(here, 'src/%s/version.py' % PACKAGE_NAME)).__version__
 
 from setuptools import setup, find_packages


### PR DESCRIPTION
Windows does not use UTF8 as the default charset, so an error occurred during installation.
I have created a pull request that solves this problem.